### PR TITLE
Pass --record flag to kubectl command

### DIFF
--- a/src/Deploy/Kubectl.php
+++ b/src/Deploy/Kubectl.php
@@ -65,7 +65,7 @@ class Kubectl implements Log\LoggerAwareInterface
         $namespace = $params['namespace'] ?? 'default';
 
         $command = sprintf(
-            'kubectl set image deploy --namespace %s %s %s=%s',
+            'kubectl set image deploy --namespace %s %s %s=%s --record',
             $namespace,
             $deployment,
             $container,


### PR DESCRIPTION
This should result in `kubectl rollout history ...` being drastically more useful for those that use it.

I'm not sure if there are any downsides to it, though I did find some quite stale meta-discussions in the k8s repo that suggested they may want to eventually deprecate the feature. It appears to have no traction at this time.